### PR TITLE
GKE legacy abac code

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,7 +40,7 @@ enabled_modules = {
 __Do not add sensitive information to the `.tfvars` file.__
 
 2. The `name` variable represents a prefix that is added to GCP resources. We suggest keeping it short and avoiding dashes, underscores, or special characters. 
-3. The `log_sink_filter` is the aggregated log sink filter. This should be as specific as possible to reduce the number of invocations of the Cloud Function. 
+3. The `log_sink_filter` is the aggregated log sink filter. This should be as specific as possible to reduce the number of invocations of the Cloud Function. Make sure to include the literal value of: __AND NOT protoPayload.authenticationInfo.principalEmail__ in your filter query so that Lockdown does not invocate based on its own actions.
 4. The `function_perms` is the Cloud Functions custom role permissions. Try to keep this as close to least privilege as possible and you must include `"logging.logEntries.create"` and `"pubsub.topics.publish"` so that the function can log and publish messages to the alerting Pub/Sub topic.
 
 ## Cloud Function Requirements

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "4.0.0"
 
-  project_id                  = var.project_id
+  project_id = var.project_id
 
   activate_apis = [
     "iam.googleapis.com",

--- a/src/README.md
+++ b/src/README.md
@@ -9,6 +9,9 @@ All lockdown remediation functions are triggered via a Pub/Sub push message base
 - TLS 1.0 is generally deprecated across many enterprise devices and is considered a weak encryption protocol. While some legacy applications still require TLS 1.0, we typically recommend customers migrate to at least TLS 1.1 but preferably 1.2.
 - This remediation will monitor for create and update events in Cloud Logging for SSL policies. If the SSL policy is using TLS 1.0, the function will update the policy to use TLS 1.1 and log the finding to Pub/Sub.
 
+## Disable Legacy auth (ABAC) on GKE clusters
+- Legacy authentication for GKE is considered unsecure and should be avoided. Organizations interested in using GKE should either use role-based authentication (RBAC) or GKE's [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). If a cluster is created with ABAC enabled or if a cluster is updated to enable ABAC, Project Lockdown will attempt to disable that setting for 5 minutes. If the 5 minute timeout is eclipsed, the function will gracefully timeout. 
+
 ## Publicly Exposed Resources
 - Publicly exposed resources pose one of the largest attack targets in the cloud. Malicious actors are constantly scanning for public resources in order to exfiltrate customer data, gain access to customer's environments, or even sabotage with an aim to disrupt workloads. With this in mind, the main bulk of our first remediations are around keeping your resources private. We try to target scenarios where there are no current safeguards available from GCP (Organization Policy constraints, for example.)
 
@@ -23,3 +26,4 @@ All lockdown remediation functions are triggered via a Pub/Sub push message base
 
 ### Remove Public IAM bindings from GCS Buckets
 - This remediation will monitor for IAM policy updates on GCS buckets and search for the public `allUsers` and `allAuthenticatedUsers` IAM bindings. If a public IAM member is currently assigned to the GCS bucket, the function will remove the binding(s) and log the finding to Pub/Sub.
+

--- a/src/legacy_gke_abac/main.py
+++ b/src/legacy_gke_abac/main.py
@@ -1,0 +1,141 @@
+import base64
+import json
+import logging
+
+from os import getenv
+from google.cloud import container
+from google.api_core import exceptions
+from google.api_core import retry
+
+from lockdown_logging import create_logger # pylint: disable=import-error
+from lockdown_pubsub import publish_message # pylint: disable=import-error
+
+def pubsub_trigger(data, context):
+    """
+    Used with Pub/Sub trigger method to evaluate the GKE cluster for legacy ABAC.
+    """
+
+    # Determine if CFN is running in view-only mode
+    try:
+        mode = getenv('MODE')
+    except:
+        logging.error('Mode not found in environment variable.')
+
+    # Determine alerting Pub/Sub topic
+    try:
+        topic_id = getenv('TOPIC_ID')
+    except:
+        logging.error('Topic ID not found in environment variable.')
+
+    # Create our GKE client
+    container_client = container.ClusterManagerClient()
+
+    # Integrates cloud logging handler to python logging
+    create_logger()
+    logging.info('Received GKE cluster log from Pub/Sub. Checking for legacy ABAC.')
+
+    # Converting log to json
+    data_buffer = base64.b64decode(data['data'])
+    log_entry = json.loads(data_buffer)
+
+    # Set our Cloud Logging variables
+    cluster_id = log_entry['protoPayload']['resourceName']
+    project_id = log_entry['resource']['labels']['project_id']
+    cluster_name = log_entry['resource']['labels']['cluster_name']
+    api_action = log_entry['protoPayload']['methodName']
+
+    # There are two different log events this function can be triggered with.
+    # One of the creation of a cluster in which we need to get the clusters data.
+    if api_action == "google.container.v1beta1.ClusterManager.CreateCluster":
+        # Get cluster details to begin evaluation logic
+        cluster_details = get_cluster_details(container_client, cluster_id)
+        # Check to see if legacy ABAC is enabled
+        abac_value = check_legacy_abac(cluster_details, cluster_id)
+    # The other log event is when a cluster's legacy auth setting is updated
+    # we can get enabled or disabled from the log event and do not need to get the cluster details
+    # This cloud function shouldn't be invocated if the API event was to disable legacy ABAC
+    # The logic below will always be set to enabled == true unless the log sink query is changed
+    # By adding this check we can skip getting the clusters data and go right to disable_legacy_abac()
+    if api_action == "google.container.v1.ClusterManager.SetLegacyAbac":
+        logging.info(f"GKE cluster: {cluster_name} was updated to enable legacy ABAC.")
+        abac_value = "enabled"
+
+    if abac_value:
+        finding_type = "gke_legacy_abac"
+        # Set our pub/sub message
+        message = f"GKE cluster: {cluster_id} has legacy ABAC enabled."
+        # Publish message to Pub/Sub
+        logging.info('Publishing message to Pub/Sub.')
+        try:
+            publish_message(finding_type, mode, cluster_name, project_id, message, topic_id)
+            logging.info(f'Published message to {topic_id}')
+        except:
+            logging.error(f'Could not publish message to {topic_id}')
+            raise
+        if mode == "write":
+            logging.info("Lockdown is in write mode.")
+            # update GKE cluster
+            disable_legacy_abac(container_client, cluster_id)
+        if mode == "read":
+            logging.info('Lockdown is in read-only mode. Taking no action.')
+
+
+def get_cluster_details(container_client, cluster_id):
+    """
+    Gets the GKE cluster's metadata.
+    This is passed to check_legacy_abac to validate the configuration.
+    """
+    try:
+        cluster_details = container_client.get_cluster(name=cluster_id)
+        return cluster_details
+    except:
+        logging.error(f"Cloud not get GKE cluster: {cluster_id} details.")
+        raise
+
+def check_legacy_abac(cluster_details, cluster_id):
+    """
+    Checks to see if Legacy ABAC is enabled.
+    We want to disable this in disable_legacy_abac because it is insecure.
+
+    ## Vars ##
+    - abac_value
+        This variable's value will either be enabled or empty.
+        If empty, ABAC is not enabled and theres nothing to do.
+        If enabled, we need to disable because ABAC is insecure.
+    """
+
+    abac_value = cluster_details.legacy_abac
+
+    if abac_value:
+        logging.info(f"GKE cluster {cluster_id} has legacy ABAC enabled.")
+        return abac_value
+    else:
+        logging.info(f"Legacy ABAC is disabled for GKE cluster: {cluster_id}. No action needed.")
+
+
+def disable_legacy_abac(container_client, cluster_id):
+    """
+    Disables legacy ABAC on the GKE cluster.
+
+    ## Vars ##
+    - my_retry
+        GKE clusters do not accept updates during cluster creation.
+        We set a retry value for the function to try every 10-30 seconds
+        for a max duration of 5 minutes.
+    """
+    my_retry = retry.Retry(predicate=exceptions.FailedPrecondition, initial=10, maximum=30, deadline=300)
+
+    try:
+        logging.info(f"Disabling Legacy ABAC on GKE cluster: {cluster_id}.")
+        # Make API call to disable ABAC
+        container_client.set_legacy_abac(name=cluster_id, enabled=False, retry=my_retry)
+        logging.info(f"Legacy ABAC disabled on GKE cluster: {cluster_id}.")
+    # Attempt to catch precondition error if retry fails
+    except exceptions.FailedPrecondition as precondition_err:
+        logging.error(f"Could not update GKE cluster: {cluster_id}. Failed with error: {precondition_err}.")
+    # Catches retry error when the 300 second deadline is hit
+    except exceptions.RetryError as retry_err:
+        logging.error(f"Could not update GKE cluster: {cluster_id}. Failed with error: {retry_err}.")
+    except:
+        logging.error(f"Could not update GKE cluster: {cluster_id}.")
+        raise

--- a/src/legacy_gke_abac/requirements.txt
+++ b/src/legacy_gke_abac/requirements.txt
@@ -1,0 +1,3 @@
+google-cloud-logging
+google-cloud-pubsub
+google-cloud-container

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -60,4 +60,13 @@
 #     log_sink_filter = "protoPayload.serviceName=\"compute.googleapis.com\" AND ((protoPayload.methodName=\"beta.compute.instances.insert\" AND protoPayload.request.serviceAccounts.email=~\"^\\d{1,12}-compute@developer.gserviceaccount.com$\") OR protoPayload.methodName=\"v1.compute.instances.start\") AND NOT protoPayload.authenticationInfo.principalEmail"
 #     function_perms = ["logging.logEntries.create", "pubsub.topics.publish", "compute.instances.get", "compute.instances.stop"],
 #   }
+#   legacy_gke_abac = {
+#     org_id = "123456",
+#     project = "test_project",
+#     region = "us-east1",
+#     mode   = "read",
+#     name = "gkeabac",
+#     log_sink_filter = "(protoPayload.methodName=\"google.container.v1beta1.ClusterManager.CreateCluster\" AND operation.first=\"true\") OR (protoPayload.methodName=\"google.container.v1.ClusterManager.SetLegacyAbac\" AND protoPayload.request.enabled=\"true\") AND NOT protoPayload.authenticationInfo.principalEmail"
+#     function_perms = ["logging.logEntries.create", "pubsub.topics.publish", "container.clusters.get", "container.clusters.update"],
+#   }
 # }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -117,7 +117,7 @@ resource "google_cloudfunctions_function" "cfn" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.cfn_bucket.name
   source_archive_object = google_storage_bucket_object.cfn_source_archive.name
-  timeout               = 60
+  timeout               = 300
   entry_point           = "pubsub_trigger"
   service_account_email = google_service_account.cfn_sa.email
   runtime               = "python38"


### PR DESCRIPTION
This PR adds functionality to disable legacy authentication (aka ABAC) on a GKE cluster when it is created OR when it is updated to enable legacy auth. 

A drawback to the way GCP handles GKE is that it takes a long time to deploy a cluster, and during that time, no actions can be made against the cluster. This means that since the Cloud Function is invocated so quickly it tries to update the cluster during creation. In order to work around this I have extended the timeout of a cloud function to 5 minutes and put a 5 minute cap on the amount time it will retry updating the GKE cluster. You can see that here:

https://github.com/ScaleSec/project_lockdown/compare/feat/itp-59?expand=1#diff-4a87ccf6b85854c2d4f55075b642cc8cc26381034ed8d8467b468db60844a84cR126

The function will try once every 10-30 seconds until it hits the 5 minute timeout ( i havent seen that happen yet). We should think about a better way to handle this like a different pub sub topic to drop messages to remediate later.