### PR TITLE
rolling back to python 3.7

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -120,7 +120,7 @@ resource "google_cloudfunctions_function" "cfn" {
   timeout               = 300
   entry_point           = "pubsub_trigger"
   service_account_email = google_service_account.cfn_sa.email
-  runtime               = "python38"
+  runtime               = "python37"
 
   event_trigger {
     event_type = "google.pubsub.topic.publish"


### PR DESCRIPTION
There is currently a bug with python 3.8 not logging to Cloud Logging. Ticket [175925410](https://issuetracker.google.com/issues/175925410) is open to track the issue.

This PR updates the python version for the Cloud Functions to 3.7