### PR TITLE
Feat 47/kms key rotation

### DIFF
--- a/docs/LOGFILTERS.md
+++ b/docs/LOGFILTERS.md
@@ -18,7 +18,7 @@ The following table contains the log sink filters (advanced log queries) used by
 | Firewall Rules | `resource.type="gce_firewall_rule" AND (protoPayload.methodName="v1.compute.firewalls.insert" OR protoPayload.methodName="v1.compute.firewalls.update" OR protoPayload.methodName="v1.compute.firewalls.patch") AND NOT protoPayload.request.disabled=true AND operation.last=true`
 | Pub/Sub Topics | `resource.type="pubsub_topic" AND protoPayload.methodName="google.iam.v1.IAMPolicy.SetIamPolicy"`
 | KMS Keys creations or updates | `protoPayload.serviceName="cloudkms.googleapis.com" AND (protoPayload.methodName="CreateCryptoKey" OR protoPayload.methodName="UpdateCryptoKey") AND resource.type="cloudkms_cryptokey"`
-| KMS Keys and key ring IAM policy public updates | `protoPayload.serviceName="cloudkms.googleapis.com" AND protoPayload.methodName="SetIamPolicy" AND (resource.type="cloudkms_cryptokey" OR resource.type="cloudkms_keyring") AND (protoPayload.request.policy.bindings.members="allAuthenticatedUsers" OR protoPayload.request.policy.bindings.members="allUsers")`
+| KMS Keys and key ring IAM policy public updates | `protoPayload.serviceName="cloudkms.googleapis.com" AND (protoPayload.methodName="CreateCryptoKey" OR (protoPayload.methodName="UpdateCryptoKey" AND protoPayload.request.updateMask=~"rotationPeriod")) AND resource.type="cloudkms_cryptokey"`
 
 
 

--- a/docs/LOGFILTERS.md
+++ b/docs/LOGFILTERS.md
@@ -4,9 +4,9 @@ Cloud Logging supports a feature called [Advanced logs queries](https://cloud.go
 
 ## Project Lockdown Log Sink Filters
 
-The following table contains the log sink filters (advanced log queries) used by Project Lockdown. Input any of the below log queries into the Cloud Logging console (steps above) to view which events will be sent to Project Lockdown. 
+The following table contains the log sink filters (advanced log queries) used by Project Lockdown. Input any of the below log queries into the Cloud Logging console (steps above) to view which events will be sent to Project Lockdown.
 
-| Product/Service | Advanced log query | 
+| Product/Service | Advanced log query |
 |-----------------|--------------------|
 | GCE Service Accounts | `protoPayload.serviceName="compute.googleapis.com" AND ((protoPayload.methodName="beta.compute.instances.insert" AND protoPayload.request.serviceAccounts.email=~"^\\d{1,12}-compute@developer.gserviceaccount.com$") OR protoPayload.methodName="v1.compute.instances.start")`
 | GCE Images | `resource.type="gce_image" protoPayload.methodName="v1.compute.images.setIamPolicy" AND (protoPayload.request.policy.bindings.members="allAuthenticatedUsers" OR protoPayload.request.policy.bindings.members="allUsers")`
@@ -17,6 +17,9 @@ The following table contains the log sink filters (advanced log queries) used by
 | GCS Buckets| `resource.type="gcs_bucket"  protoPayload.methodName="storage.setIamPermissions"`
 | Firewall Rules | `resource.type="gce_firewall_rule" AND (protoPayload.methodName="v1.compute.firewalls.insert" OR protoPayload.methodName="v1.compute.firewalls.update" OR protoPayload.methodName="v1.compute.firewalls.patch") AND NOT protoPayload.request.disabled=true AND operation.last=true`
 | Pub/Sub Topics | `resource.type="pubsub_topic" AND protoPayload.methodName="google.iam.v1.IAMPolicy.SetIamPolicy"`
+| KMS Keys creations or updates | `protoPayload.serviceName="cloudkms.googleapis.com" AND (protoPayload.methodName="CreateCryptoKey" OR protoPayload.methodName="UpdateCryptoKey") AND resource.type="cloudkms_cryptokey"`
+| KMS Keys and key ring IAM policy public updates | `protoPayload.serviceName="cloudkms.googleapis.com" AND protoPayload.methodName="SetIamPolicy" AND (resource.type="cloudkms_cryptokey" OR resource.type="cloudkms_keyring") AND (protoPayload.request.policy.bindings.members="allAuthenticatedUsers" OR protoPayload.request.policy.bindings.members="allUsers")`
+
 
 
 __Note:__ The above queries have been modified to work in the GCP console from their terraform configuration. In terraform we add an extra parameter to not invocate when Project Lockdown performs an action. Without that additional config, Project Lockdown would invocate itself causing additional costs. To view the terraform log sink filters view the example `tfvars` file [here](../terraform.tfvars).

--- a/main.tf
+++ b/main.tf
@@ -48,4 +48,5 @@ module "function" {
   topic_id         = google_pubsub_topic.alerting_topic.name
   project_list     = lookup(each.value, "allowlist", var.project_list)
   list_type        = lookup(each.value, "allowlist", var.list_type)
+  rotation_period  = var.rotation_period
 }

--- a/src/README.md
+++ b/src/README.md
@@ -1,34 +1,39 @@
 # Project Lockdown Automated Remediation Scenarios
 All lockdown remediation functions are triggered via a Pub/Sub push message based on a specific log sink query. You can find examples in the [documentation](../docs/LOGFILTERS.md). Keep in mind that by default Project Lockdown deploys in read only. You will need to update the `mode` variable in your [terraform.tfvars](../terraform.tfvars) file to be "write" in order to turn on automate remediations.
 
-## Deny use of the default compute service account on GCE Instances
+## Deny use of the default compute service account on GCE instances
 - The use of the [default compute service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account) on GCE instances is a potentially large security risk due to the IAM role `roles/editor` being applied to the SA. Typically this IAM role is overly permissive for workloads in GCE and should be avoided. A best practice is to avoid all [basic IAM roles](https://cloud.google.com/iam/docs/understanding-roles#basic) (previously called primitive roles) and instead create custom least privilege roles.
 - This remediation function will monitor for create and start events for GCE instances in Cloud Logging and analyze the assigned service account. If the GCE instance is using the default compute service account the function will stop the instance and log the finding to Pub/Sub.
 
-## Update weak TLS 1.0 to 1.1 on SSL Policies
+## Update weak TLS 1.0 to 1.1 on SSL policies
 - TLS 1.0 is generally deprecated across many enterprise devices and is considered a weak encryption protocol. While some legacy applications still require TLS 1.0, we typically recommend customers migrate to at least TLS 1.1 but preferably 1.2.
 - This remediation will monitor for create and update events in Cloud Logging for SSL policies. If the SSL policy is using TLS 1.0, the function will update the policy to use TLS 1.1 and log the finding to Pub/Sub.
 
-## Disable Legacy auth (ABAC) on GKE clusters
-- Legacy authentication for GKE is considered unsecure and should be avoided. Organizations interested in using GKE should either use role-based authentication (RBAC) or GKE's [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). If a cluster is created with ABAC enabled or if a cluster is updated to enable ABAC, Project Lockdown will attempt to disable that setting for 5 minutes. If the 5 minute timeout is eclipsed, the function will gracefully timeout. 
+## Disable legacy auth (ABAC) on GKE clusters
+- Legacy authentication for GKE is considered unsecure and should be avoided. Organizations interested in using GKE should either use role-based authentication (RBAC) or GKE's [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). If a cluster is created with ABAC enabled or if a cluster is updated to enable ABAC, Project Lockdown will attempt to disable that setting for 5 minutes. If the 5 minute timeout is eclipsed, the function will gracefully timeout.
 
-## Publicly Exposed Resources
+## Enforce Cloud KMS key rotation periods
+- Regularly rotating encryption (crypto) keys is an industry-standard best practice but not required by default in GCP. This remediation monitors for key creations and updates to rotation periods to verify that the rotation period value is set at or more frequently than an approved number of days.
+- For example, by default Project Lockdown sets the desired rotation period to 90 days, but this value is customizable. If a user creates a Cloud KMS key, and sets the rotation period to None, or 180 days, Project Lockdown would be invocated and would update the rotation period to 90 days.
+- __Note:__ Rotation periods are only supported for symmetric keys at this time in GCP.
+
+## Publicly exposed resources
 - Publicly exposed resources pose one of the largest attack targets in the cloud. Malicious actors are constantly scanning for public resources in order to exfiltrate customer data, gain access to customer's environments, or even sabotage with an aim to disrupt workloads. With this in mind, the main bulk of our first remediations are around keeping your resources private. We try to target scenarios where there are no current safeguards available from GCP (Organization Policy constraints, for example.)
 
-### Remove Public IAM bindings from BigQuery datasets
+### Remove public IAM bindings from BigQuery datasets
 - This remediation will monitor for IAM policy updates on BigQuery datasets and search for the public `allUsers` and `allAuthenticatedUsers` IAM bindings. If either of those are currently assigned to the dataset, the function will remove the binding(s) and log the finding to Pub/Sub.
 
-### Remove Public IAM bindings from BigQuery Tables
+### Remove public IAM bindings from BigQuery tables
 - This remediation will monitor for IAM policy updates on BigQuery tables and search for the public `allUsers` and `allAuthenticatedUsers` IAM bindings. If either of those are currently assigned to the table, the function will remove the binding(s) and log the finding to Pub/Sub.
 
-### Remove Public IAM bindings from GCE Images
+### Remove public IAM bindings from GCE images
 - This remediation will monitor for IAM policy updates on GCE images and search for the public `allAuthenticatedUsers` IAM binding (`allUsers` is not supported on this resource type but we still look for it in the Cloud Logging query). If a public IAM member is currently assigned to the GCE image, the function will remove the binding and log the finding to Pub/Sub.
 
-### Remove Public IAM bindings from GCS Buckets
+### Remove public IAM bindings from GCS buckets
 - This remediation will monitor for IAM policy updates on GCS buckets and search for the public `allUsers` and `allAuthenticatedUsers` IAM bindings. If a public IAM member is currently assigned to the GCS bucket, the function will remove the binding(s) and log the finding to Pub/Sub.
 
-### Disable Firewalls with 0.0.0.0/0 ingress source ranges
+### Disable firewalls with 0.0.0.0/0 ingress source ranges
 - This remediation will monitor for updates to existing firewalls and creation of new firewalls. It will check for 0.0.0.0/0 in source ranges of the firewall, and if it does exist, disable the firewall and log the finding to Pub/Sub.
 
-### Remove Public IAM bindings from Pub/Sub Topics
+### Remove public IAM bindings from Pub/Sub topics
 - This remediation will monitor for IAM policy updates on Pub/Sub Topics and search for the public `allUsers` and `allAuthenticatedUsers` IAM bindings. If a public IAM member is currently assigned to the topic, the function will remove the binding(s) and log the finding to Pub/Sub.

--- a/src/README.md
+++ b/src/README.md
@@ -15,6 +15,7 @@ All lockdown remediation functions are triggered via a Pub/Sub push message base
 ## Enforce Cloud KMS key rotation periods
 - Regularly rotating encryption (crypto) keys is an industry-standard best practice but not required by default in GCP. This remediation monitors for key creations and updates to rotation periods to verify that the rotation period value is set at or more frequently than an approved number of days.
 - For example, by default Project Lockdown sets the desired rotation period to 90 days, but this value is customizable. If a user creates a Cloud KMS key, and sets the rotation period to None, or 180 days, Project Lockdown would be invocated and would update the rotation period to 90 days.
+- This remediation also sets the key to be rotated in the next 24 hours.
 - __Note:__ Rotation periods are only supported for symmetric keys at this time in GCP.
 
 ## Publicly exposed resources

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -83,7 +83,7 @@ def pubsub_trigger(data, context):
     crypto_key_metadata = get_key_data(client, key_name)
 
     # Get rotation period from key metadata
-    rotation_period = find_rotation_period(client, crypto_key_metadata)
+    rotation_period = find_rotation_period(crypto_key_metadata)
 
     # Review the rotation period against
     # approved rotation period. Defaults to 90d (7776000s)
@@ -116,7 +116,7 @@ def get_key_data(client, key_name):
 
     return crypto_key_metadata
 
-def find_rotation_period(client, crypto_key_metadata):
+def find_rotation_period(crypto_key_metadata):
     """
     Using the keys metadata, find the crypto keys rotation period
 

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -1,0 +1,266 @@
+import logging
+import sys
+import time
+import base64
+import json
+
+from os import getenv
+from google.cloud import kms # pylint: disable=import-error
+from google.api_core import exceptions # pylint: disable=import-error
+
+from lockdown_logging import create_logger # pylint: disable=import-error
+from lockdown_pubsub import publish_message # pylint: disable=import-error
+from lockdown_checklist import check_list # pylint: disable=import-error
+
+def pubsub_trigger(data, context):
+    """
+    Used with Pub/Sub trigger method to evaluate a crypto key
+    rotation period
+
+    Args:
+
+    data - Contains the Pub/Sub message
+    context -  The Cloud Functions event metdata
+    """
+
+    # Integrates cloud logging handler to python logging
+    create_logger()
+    logging.info(
+        "Received Cloud KMS crypto key creation or update log event. \n Evaluation rotation period." # pylint: disable=line-too-long
+    )
+
+    # Determine if lockdown is running in view-only mode
+    try:
+        mode = getenv("MODE")
+    except:
+        logging.error("Mode not found in environment variable.")
+
+    # Determine alerting Pub/Sub topic
+    try:
+        topic_id = getenv("TOPIC_ID")
+    except:
+        logging.error("Topic ID not found in environment variable.")
+
+    # Converting log to json
+    data_buffer = base64.b64decode(data["data"])
+    log_entry = json.loads(data_buffer)
+
+    # Parse log entry for variables
+    crypto_key_id = log_entry["resource"]["labels"]["crypto_key_id"]
+    project_id = log_entry["resource"]["labels"]["project_id"]
+    key_ring_id = log_entry["resource"]["labels"]["key_ring_id"]
+    location = log_entry["resource"]["labels"]["location"]
+
+    # Check our project_id against allow / denylist
+    if check_list(project_id):
+        logging.info(
+            "The project %s is not in the allowlist, is in the denylist, or a list is not fully configured. \n Continuing evaluation.", # pylint: disable=line-too-long
+            project_id
+        )
+    else:
+        logging.info(
+            "The project %sis in the allowlist or is not in the denylist. No action being taken.", # pylint: disable=line-too-long
+            project_id
+        )
+        sys.exit(0)
+    # If the project ID is not in the allow / denylist
+    # Continue with evaluation
+
+    # Create the KMS client
+    client = kms.KeyManagementServiceClient()
+
+    # Build the parent key name.
+    key_name = client.crypto_key_path(
+        project_id,
+        location,
+        key_ring_id,
+        crypto_key_id
+    )
+
+    # Call the function to capture
+    # crypto key metadata
+    crypto_key_metadata = get_key_data(client, key_name)
+
+    # Get rotation period from key metadata
+    rotation_period = find_rotation_period(client, crypto_key_metadata)
+
+    # Review the rotation period against
+    # approved rotation period. Defaults to 90d (7776000s)
+    review_rotation_period(
+        rotation_period,
+        crypto_key_metadata,
+        crypto_key_id,
+        project_id,
+        mode,
+        topic_id
+    )
+
+def get_key_data(client, key_name):
+    """
+    Gets KMS crypto key metadata.
+
+    Args:
+    client - The Cloud KMS client used to call APIs.
+    key_name - The full crypto key resource name.
+
+    Returns:
+    crypto_key_metadata - Cloud KMS crypto key metadata
+    """
+
+    logging.info("Getting %s metadata", key_name)
+    try:
+        crypto_key_metadata = client.get_crypto_key(name = key_name)
+    except:
+        print("Error") ##TODO: better error capture
+
+    return crypto_key_metadata
+
+def find_rotation_period(client, crypto_key_metadata):
+    """
+    Using the keys metadata, find the crypto keys rotation period
+
+    Args:
+    client - The Cloud KMS client used to call APIs.
+    crypto_key_metadata - The crypto key"s metadata.
+
+    Returns:
+    rotation_period - The crypto key rotation period.
+    """
+    # Check to see if the crypto key is symmetric
+    # Asymmetric encryption keys do not support rotation periods
+    if crypto_key_metadata.primary.algorithm.GOOGLE_SYMMETRIC_ENCRYPTION == 1:
+        logging.info(
+            "Cloud KMS crypto key is a symmetric encryption key. \n Checking rotation period." # pylint: disable=line-too-long
+        )
+    else:
+        logging.info(
+            "Cloud KMS crypto key is not using symmetric encryption, rotation periods are not supported. \n Exiting" # pylint: disable=line-too-long
+        )
+        sys.exit(0)
+    # If the crypto key does not have a rotation period
+    # Set the period to 0
+    if not crypto_key_metadata.rotation_period:
+        logging.info(
+            "Cloud KMS crypto key %s has no rotation period configured.",
+            crypto_key_metadata.name
+        )
+
+        # Set the rotation period to None and return
+        crypto_key_metadata.rotation_period = None
+        rotation_period = crypto_key_metadata.rotation_period
+        return rotation_period #TODO: Uncomment
+    # Return the rotation period for analysis
+    else:
+        rotation_period = crypto_key_metadata.rotation_period
+        return rotation_period
+
+def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, project_id, mode, topic_id): # pylint: disable=line-too-long
+    """
+    Reviews the rotation period against a known value.
+    If rotation period is over the value (aka longer) or None,
+    call the remediate function to set to known value.
+
+    Args:
+    rotation_period - The crypto keys rotation period.
+    crypto_key_metadata - The crypto keys metadata information.
+    """
+
+    # Configure Pub/Sub variables
+    finding_type = "kms_bad_rotation_period"
+    # Set our pub/sub message
+    message = f"Long or no rotation period on {crypto_key_id} in project: {project_id}."
+
+    # Rotation period evaluation logic
+    # If the rotation period on the crypto key is LONGER
+    if rotation_period > 7776000: #TODO: move to user selected value
+        logging.info(
+            "Cloud KMS crypto key %s has a rotation period longer than %s",
+            crypto_key_metadata.name
+        ) ##TODO: Add user value # pylint: disable=line-too-long
+
+        # Publish message to Pub/Sub
+        logging.info("Publishing message to Pub/Sub.")
+        try:
+            publish_message(
+                finding_type,
+                mode,
+                crypto_key_metadata.name,
+                project_id,
+                message,
+                topic_id
+            )
+            logging.info("Published message to %s", topic_id)
+        except:
+            logging.error("Could not publish message to %s", topic_id)
+
+        # Update the rotation period to specified value
+        update_rotation_period(crypto_key_metadata) #TODO: Add user value
+
+    # Or if there is no rotation period
+    elif rotation_period is None:
+        logging.info(
+            "Cloud KMS crypto key %s has a rotation period longer than %s",
+            crypto_key_metadata.name
+        ) ##TODO: Add user value
+
+        # Publish message to Pub/Sub
+        logging.info("Publishing message to Pub/Sub.")
+        try:
+            publish_message(
+                finding_type,
+                mode,
+                crypto_key_metadata.name,
+                project_id,
+                message,
+                topic_id
+            )
+            logging.info("Published message to %s", topic_id)
+        except:
+            logging.error("Could not publish message to %s", topic_id)
+
+        # Update the rotation period to specified value
+        update_rotation_period(crypto_key_metadata) #TODO: Add user value
+
+    # Or if the rotation period is under
+    elif rotation_period <= 7776000: #TODO: move to user selected value
+        logging.info(
+            "Cloud KMS crypto key %s has a rotation period under the requirement. \n Exiting.",
+            crypto_key_metadata.name
+        ) ##TODO: Add user value
+        sys.exit(0)
+
+def update_rotation_period(crypto_key_metadata):
+    """
+    Updates the crypto keys rotation period to known value.
+
+    Args:
+    crypto_key_metadata - The crypto keys metadata information.
+    some_user_value-
+    """
+
+    # Create the client.
+    client = kms.KeyManagementServiceClient()
+
+    # Set the key name for the update call
+    crypto_key_name = crypto_key_metadata.name
+
+    key = {
+        "name": crypto_key_name,
+        "rotation_period": {
+            "seconds": 60*60*24*30  # Rotate the key every 30 days. ##TODO: Configure for user value
+        },
+        "next_rotation_time": {
+            "seconds": int(time.time()) + 60*60*24  # Start the first rotation in 24 hours. ##TODO: Configure for user value # pylint: disable=line-too-long
+        }
+    }
+
+    # Build the update mask to set a new retention policy.
+    update_mask = {"paths": ["rotation_period", "next_rotation_time"]}
+
+    # Update the rotation period
+    client.update_crypto_key(
+        request={
+        "crypto_key": key,
+        "update_mask": update_mask
+        }
+    ) ##TODO: add error handling

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -232,7 +232,7 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
     # Or if the rotation period is under
     elif rotation_period <= approved_rotation_period_seconds:
         logging.info(
-            "Cloud KMS crypto key %s has a rotation period less than the requirement of %s days. \n Exiting.",
+            "Cloud KMS crypto key %s has a rotation period less than the requirement of %s days. \n Exiting.", # pylint: disable=line-too-long
             crypto_key_metadata.name, approved_rotation_period
         )
 

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -3,6 +3,7 @@ import sys
 import time
 import base64
 import json
+import datetime
 
 from os import getenv
 from google.cloud import kms # pylint: disable=import-error
@@ -130,11 +131,13 @@ def find_rotation_period(client, crypto_key_metadata):
     # Asymmetric encryption keys do not support rotation periods
     if crypto_key_metadata.primary.algorithm.GOOGLE_SYMMETRIC_ENCRYPTION == 1:
         logging.info(
-            "Cloud KMS crypto key is a symmetric encryption key. \n Checking rotation period." # pylint: disable=line-too-long
+            "Cloud KMS crypto key %s is a symmetric encryption key. \n Checking rotation period.",
+            crypto_key_metadata.name
         )
     else:
         logging.info(
-            "Cloud KMS crypto key is not using symmetric encryption, rotation periods are not supported. \n Exiting" # pylint: disable=line-too-long
+            "Cloud KMS crypto key %s is not using symmetric encryption, rotation periods are not supported. \n Exiting",
+            crypto_key_metadata.name # pylint: disable=line-too-long
         )
         sys.exit(0)
     # If the crypto key does not have a rotation period
@@ -146,12 +149,19 @@ def find_rotation_period(client, crypto_key_metadata):
         )
 
         # Set the rotation period to None and return
-        crypto_key_metadata.rotation_period = None
-        rotation_period = crypto_key_metadata.rotation_period
-        return rotation_period #TODO: Uncomment
+        rotation_period = None
+        return rotation_period
     # Return the rotation period for analysis
     else:
-        rotation_period = crypto_key_metadata.rotation_period
+        # Capture the rotation period in days
+        rotation_period_days = crypto_key_metadata.rotation_period.days
+        logging.info(
+            "Cloud KMS crypto key %s has a rotation period of %s days.",
+            crypto_key_metadata.name, rotation_period_days
+        )
+        # Convert to seconds
+        rotation_period = datetime.timedelta(seconds=24*60*60*rotation_period_days).total_seconds()
+
         return rotation_period
 
 def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, project_id, mode, topic_id): # pylint: disable=line-too-long
@@ -163,6 +173,10 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
     Args:
     rotation_period - The crypto keys rotation period.
     crypto_key_metadata - The crypto keys metadata information.
+    crypto_key_id - The crypto key ID for the pub/sub message.
+    project_id - The project ID for the pub/sub message.
+    mode - Lockdown mode for pub/sub message.
+    topic_id - The pub/sub message topic ID.
     """
 
     # Configure Pub/Sub variables
@@ -172,36 +186,12 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
 
     # Rotation period evaluation logic
     # If the rotation period on the crypto key is LONGER
-    if rotation_period > 7776000: #TODO: move to user selected value
+    if rotation_period > 7776000 or None: #TODO: move to user selected value
         logging.info(
-            "Cloud KMS crypto key %s has a rotation period longer than %s",
-            crypto_key_metadata.name
-        ) ##TODO: Add user value # pylint: disable=line-too-long
-
-        # Publish message to Pub/Sub
-        logging.info("Publishing message to Pub/Sub.")
-        try:
-            publish_message(
-                finding_type,
-                mode,
-                crypto_key_metadata.name,
-                project_id,
-                message,
-                topic_id
-            )
-            logging.info("Published message to %s", topic_id)
-        except:
-            logging.error("Could not publish message to %s", topic_id)
-
-        # Update the rotation period to specified value
-        update_rotation_period(crypto_key_metadata) #TODO: Add user value
-
-    # Or if there is no rotation period
-    elif rotation_period is None:
-        logging.info(
-            "Cloud KMS crypto key %s has a rotation period longer than %s",
+            "Cloud KMS crypto key %s has an invalid rotation period.",
             crypto_key_metadata.name
         ) ##TODO: Add user value
+        #logging.info("Cloud KMS crypto key rotation periods need to be %s or under", ) ##TODO: Custom value
 
         # Publish message to Pub/Sub
         logging.info("Publishing message to Pub/Sub.")
@@ -219,7 +209,8 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
             logging.error("Could not publish message to %s", topic_id)
 
         # Update the rotation period to specified value
-        update_rotation_period(crypto_key_metadata) #TODO: Add user value
+        logging.info("Updating the rotation period on Cloud KMS crypto key %s", crypto_key_id)
+        update_rotation_period(crypto_key_metadata, crypto_key_id) #TODO: Add user value
 
     # Or if the rotation period is under
     elif rotation_period <= 7776000: #TODO: move to user selected value
@@ -227,15 +218,14 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
             "Cloud KMS crypto key %s has a rotation period under the requirement. \n Exiting.",
             crypto_key_metadata.name
         ) ##TODO: Add user value
-        sys.exit(0)
 
-def update_rotation_period(crypto_key_metadata):
+def update_rotation_period(crypto_key_metadata, crypto_key_id):
     """
     Updates the crypto keys rotation period to known value.
 
     Args:
     crypto_key_metadata - The crypto keys metadata information.
-    some_user_value-
+    some_user_value -
     """
 
     # Create the client.
@@ -244,10 +234,11 @@ def update_rotation_period(crypto_key_metadata):
     # Set the key name for the update call
     crypto_key_name = crypto_key_metadata.name
 
+    # Configure crypto key metadata
     key = {
         "name": crypto_key_name,
         "rotation_period": {
-            "seconds": 60*60*24*30  # Rotate the key every 30 days. ##TODO: Configure for user value
+            "seconds": 60*60*24*90  # Rotate the key every 90 days. ##TODO: Configure for user value
         },
         "next_rotation_time": {
             "seconds": int(time.time()) + 60*60*24  # Start the first rotation in 24 hours. ##TODO: Configure for user value # pylint: disable=line-too-long
@@ -258,9 +249,14 @@ def update_rotation_period(crypto_key_metadata):
     update_mask = {"paths": ["rotation_period", "next_rotation_time"]}
 
     # Update the rotation period
-    client.update_crypto_key(
-        request={
-        "crypto_key": key,
-        "update_mask": update_mask
-        }
-    ) ##TODO: add error handling
+    try:
+        logging.info("Attempting to update crypto key %s", crypto_key_id)
+        client.update_crypto_key(
+            request={
+            "crypto_key": key,
+            "update_mask": update_mask
+            }
+        ) ##TODO: add better error handling
+        logging.info("Update on %s successful.", crypto_key_id)
+    except:
+        logging.error("Error updating crypto key %s", crypto_key_name)

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -148,8 +148,9 @@ def find_rotation_period(client, crypto_key_metadata):
             crypto_key_metadata.name
         )
 
-        # Set the rotation period to None and return
-        rotation_period = None
+        # Set the rotation period to an unrealistic date
+        # In 2021, this date would be year 2295
+        rotation_period = 8639913600 # seconds
         return rotation_period
     # Return the rotation period for analysis
     else:
@@ -186,7 +187,7 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
 
     # Rotation period evaluation logic
     # If the rotation period on the crypto key is LONGER
-    if rotation_period > 7776000 or None: #TODO: move to user selected value
+    if rotation_period > 7776000: #TODO: move to user selected value
         logging.info(
             "Cloud KMS crypto key %s has an invalid rotation period.",
             crypto_key_metadata.name

--- a/src/kms_key_rotation/main.py
+++ b/src/kms_key_rotation/main.py
@@ -111,8 +111,8 @@ def get_key_data(client, key_name):
     logging.info("Getting %s metadata", key_name)
     try:
         crypto_key_metadata = client.get_crypto_key(name = key_name)
-    except:
-        print("Error") ##TODO: better error capture
+    except exceptions.PermissionDenied as perm_err:
+        logging.error("Error getting crypto key %s", perm_err)
 
     return crypto_key_metadata
 
@@ -136,8 +136,8 @@ def find_rotation_period(client, crypto_key_metadata):
         )
     else:
         logging.info(
-            "Cloud KMS crypto key %s is not using symmetric encryption, rotation periods are not supported. \n Exiting",
-            crypto_key_metadata.name # pylint: disable=line-too-long
+            "Cloud KMS crypto key %s is not using symmetric encryption, rotation periods are not supported. \n Exiting", # pylint: disable=line-too-long
+            crypto_key_metadata.name
         )
         sys.exit(0)
     # If the crypto key does not have a rotation period
@@ -192,7 +192,7 @@ def review_rotation_period(rotation_period, crypto_key_metadata, crypto_key_id, 
             "Cloud KMS crypto key %s has an invalid rotation period.",
             crypto_key_metadata.name
         ) ##TODO: Add user value
-        #logging.info("Cloud KMS crypto key rotation periods need to be %s or under", ) ##TODO: Custom value
+        #logging.info("Cloud KMS crypto key rotation periods need to be %s or under", ) ##TODO: Custom value # pylint: disable=line-too-long
 
         # Publish message to Pub/Sub
         logging.info("Publishing message to Pub/Sub.")
@@ -257,7 +257,7 @@ def update_rotation_period(crypto_key_metadata, crypto_key_id):
             "crypto_key": key,
             "update_mask": update_mask
             }
-        ) ##TODO: add better error handling
+        )
         logging.info("Update on %s successful.", crypto_key_id)
-    except:
-        logging.error("Error updating crypto key %s", crypto_key_name)
+    except exceptions.PermissionDenied as perm_err:
+        logging.error("Error updating crypto key %s", perm_err)

--- a/src/kms_key_rotation/requirements.txt
+++ b/src/kms_key_rotation/requirements.txt
@@ -1,2 +1,3 @@
 google-cloud-kms
 google-cloud-logging
+google-cloud-pubsub

--- a/src/kms_key_rotation/requirements.txt
+++ b/src/kms_key_rotation/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-kms
+google-cloud-logging

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -66,4 +66,10 @@
 #     log_sink_filter = "resource.type=\"pubsub_topic\" AND protoPayload.methodName=\"google.iam.v1.IAMPolicy.SetIamPolicy\" AND NOT protoPayload.authenticationInfo.principalEmail",
 #     function_perms  = ["logging.logEntries.create", "pubsub.topics.publish", "pubsub.topics.setIamPolicy", "pubsub.topics.getIamPolicy"],
 #   }
+#   kms_key_rotation = {
+#     lockdown_project = "test_project",
+#     name   = "kmsrotation",
+#     log_sink_filter = "protoPayload.serviceName=\"cloudkms.googleapis.com\" AND (protoPayload.methodName=\"CreateCryptoKey\" OR protoPayload.methodName=\"UpdateCryptoKey\") AND resource.type=\"cloudkms_cryptokey\" AND NOT protoPayload.authenticationInfo.principalEmail",
+#     function_perms  = ["logging.logEntries.create", "pubsub.topics.publish", "cloudkms.cryptoKeys.get", "cloudkms.cryptoKeys.update"],
+#   }
 # }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -69,7 +69,7 @@
 #   kms_key_rotation = {
 #     lockdown_project = "test_project",
 #     name   = "kmsrotation",
-#     log_sink_filter = "protoPayload.serviceName=\"cloudkms.googleapis.com\" AND (protoPayload.methodName=\"CreateCryptoKey\" OR protoPayload.methodName=\"UpdateCryptoKey\") AND resource.type=\"cloudkms_cryptokey\" AND NOT protoPayload.authenticationInfo.principalEmail",
+#     log_sink_filter  = "protoPayload.serviceName=\"cloudkms.googleapis.com\" AND (protoPayload.methodName=\"CreateCryptoKey\" OR (protoPayload.methodName=\"UpdateCryptoKey\" AND protoPayload.request.updateMask=~\"rotationPeriod\")) AND resource.type=\"cloudkms_cryptokey\" AND NOT protoPayload.authenticationInfo.principalEmail",
 #     function_perms  = ["logging.logEntries.create", "pubsub.topics.publish", "cloudkms.cryptoKeys.get", "cloudkms.cryptoKeys.update"],
 #   }
 # }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,7 +100,7 @@ data "archive_file" "source" {
 resource "google_storage_bucket" "cfn_bucket" {
   project = var.lockdown_project
   name    = "${lower(var.name)}-${var.function_name}_cfn_bucket_${var.lockdown_project}"
-  
+
   uniform_bucket_level_access = true
 }
 
@@ -113,11 +113,11 @@ resource "google_storage_bucket_object" "cfn_source_archive" {
 
 ## Cloud Function
 resource "google_cloudfunctions_function" "cfn" {
-  name                  = local.function_name
-  description           = "Cloud Function to remediate ${var.function_name}."
+  name        = local.function_name
+  description = "Cloud Function to remediate ${var.function_name}."
 
-  project               = var.lockdown_project
-  available_memory_mb   = var.function_memory
+  project             = var.lockdown_project
+  available_memory_mb = var.function_memory
 
   source_archive_bucket = google_storage_bucket.cfn_bucket.name
   source_archive_object = google_storage_bucket_object.cfn_source_archive.name
@@ -132,9 +132,10 @@ resource "google_cloudfunctions_function" "cfn" {
   }
 
   environment_variables = {
-    MODE         = var.mode
-    TOPIC_ID     = var.topic_id
-    PROJECT_LIST = var.project_list
-    LIST_TYPE    = var.list_type
+    MODE            = var.mode
+    TOPIC_ID        = var.topic_id
+    PROJECT_LIST    = var.project_list
+    LIST_TYPE       = var.list_type
+    ROTATION_PERIOD = var.rotation_period
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,3 +53,9 @@ variable "function_memory" {
   type        = number
   description = "Memory available to a function"
 }
+
+variable "rotation_period" {
+  type        = number
+  default     = 90
+  description = "The approved rotation period, in days, for Cloud KMS keys."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "project_list" {
   type        = string
   default     = "N/A"
 }
+
+variable "rotation_period" {
+  type        = number
+  default     = 90
+  description = "The approved rotation period, in days, for Cloud KMS keys."
+}


### PR DESCRIPTION
- Regularly rotating encryption (crypto) keys is an industry-standard best practice but not required by default in GCP. This remediation monitors for key creations and updates to rotation periods to verify that the rotation period value is set at or more frequently than an approved number of days.
- For example, by default Project Lockdown sets the desired rotation period to 90 days, but this value is customizable. If a user creates a Cloud KMS key, and sets the rotation period to None, or 180 days, Project Lockdown would be invocated and would update the rotation period to 90 days.
- This remediation also sets the key to be rotated in the next 24 hours.
- __Note:__ Rotation periods are only supported for symmetric keys at this time in GCP.


closes #47 