### PR TITLE
Testing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.tfstate
 *.tfstate.*
 
+tfplan.out
+
 # Crash log files
 crash.log
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 ![Code Coverage](./.coverage.svg) [![GitHub Super-Linter](https://github.com/ScaleSec/project_lockdown/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
 
 ## Introduction
-Project Lockdown is a collection of serverless event-driven auto remediation Cloud Functions designed to react to unsecure resource creations or configurations. Project Lockdown is meant to be deployed in a GCP environment and has the capabilities to monitor and remediate across your entire Organization hierarchy in a matter of seconds. 
+Project Lockdown is a collection of serverless event-driven auto remediation Cloud Functions designed to react to unsecure resource creations or configurations. Project Lockdown is meant to be deployed in a GCP environment and has the capabilities to monitor and remediate across your entire Organization hierarchy in a matter of seconds.
 
 ## Why is this needed?
-Project Lockdown was born out of a common theme from our customers - there are certain configurations or events that they do not want to happen but there are currently no provider-native controls available to prevent these actions. For example, making a [GCS bucket](https://cloud.google.com/storage/docs/access-control/making-data-public) or [BigQuery dataset](https://cloud.google.com/bigquery/docs/datasets-intro) that stores sensitive information public puts your data at risk and it can only take minutes for malicious individuals to find those resources and exfiltrate data. 
+Project Lockdown was born out of a common theme from our customers - there are certain configurations or events that they do not want to happen but there are currently no provider-native controls available to prevent these actions. For example, making a [GCS bucket](https://cloud.google.com/storage/docs/access-control/making-data-public) or [BigQuery dataset](https://cloud.google.com/bigquery/docs/datasets-intro) that stores sensitive information public puts your data at risk and it can only take minutes for malicious individuals to find those resources and exfiltrate data.
 
 There are compensating controls like the Organization Policy [constraint](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints) `constraints/iam.allowedPolicyMemberDomains` that attempt to prevent GCS buckets from being made public but have potentially negative side effects. Organizations must constantly keep a running list of Google Workspace IDs (formally G Suite) and also track where and when hierarchies are broken which adds operational overhead.
 
 Project Lockdown aims to be a safe, lightweight, and inexpensive tool to increase your security posture.
 
 ## How does it work?
-Project Lockdown works by using a very efficient data flow that takes advantage of GCP's [Cloud Logging](https://cloud.google.com/logging/docs/basic-concepts) advanced query log sinks. By configuring a filter (query) as specific as possible on the log sink, Project Lockdown will only invocate a Cloud Function when necessary to remediate events deemed high risk or unsecure. 
+Project Lockdown works by using a very efficient data flow that takes advantage of GCP's [Cloud Logging](https://cloud.google.com/logging/docs/basic-concepts) advanced query log sinks. By configuring a filter (query) as specific as possible on the log sink, Project Lockdown will only invocate a Cloud Function when necessary to remediate events deemed high risk or unsecure.
 
-When a target event is captured by the log sink it is sent to a Cloud Pub/Sub topic that triggers a Cloud Function automatically. This Cloud Function analyzes the event payload and extracts the data necessary for it to evaluate the current resource's configuration. If the Cloud Function determines that the resource is misconfigured according to its evaluation logic it will remediate the resource and reconfigure it in a safe manner. Typically, the action taken by the Cloud Function is a reversal of the event. If a bucket was made public, it is made private, but if a SSL policy is created using `TLS 1.0`, it will be updated to `TLS 1.1`. 
+When a target event is captured by the log sink it is sent to a Cloud Pub/Sub topic that triggers a Cloud Function automatically. This Cloud Function analyzes the event payload and extracts the data necessary for it to evaluate the current resource's configuration. If the Cloud Function determines that the resource is misconfigured according to its evaluation logic it will remediate the resource and reconfigure it in a safe manner. Typically, the action taken by the Cloud Function is a reversal of the event. If a bucket was made public, it is made private, but if a SSL policy is created using `TLS 1.0`, it will be updated to `TLS 1.1`.
 
 ## How can I trust this?
 Trust is a key component of any security tool so Project Lockdown is built with that in mind. A few examples of this are:
@@ -45,7 +45,7 @@ To view which log events Project Lockdown monitors for, view the [documentation]
 Project Lockdown is under active development and we welcome any questions, bug reports, feature requests or enhancements via a GitHub Issue or Pull Request. If you plan to contribute to Project Lockdown please follow our [Contribution Guidelines](docs/CONTRIBUTING.md) for suggestions and requirements.
 
 
-## Usage 
+## Usage
 
 ### Modes
 
@@ -69,12 +69,28 @@ make test
 
 Project Lockdown is able to deploy many different remediation functions and their accompanying resources using the [module](https://learn.hashicorp.com/tutorials/terraform/for-each) `for_each` functionality. This allows us to only specify one `main.tf` in the [terraform](./terraform) directory but deploy as many copies as there are entries in the variable `enabled_modules`.
 
-To configure Terraform for a deployment:
+### Deployment
 
 - Copy `terraform.tfvars` into a file that ends in `.auto.tfvars` and edit the `enabled_modules` variable as desired (remember to uncomment the necessary lines).
 - To enable automatic remediation, be sure to set the `mode` variable as `write`
-- We do not recommend updating the variables `log_sink_filter` or `function_perms` because those have been tailored to work with Project Lockdown. 
+- We do not recommend updating the variables `log_sink_filter` or `function_perms` because those have been tailored to work with Project Lockdown.
 - We DO recommend deploying all Lockdown resources into an isolated security project, including the Pub/Sub topic for alerts.
+
+```bash
+# To deploy Project Lockdown
+
+# First initialize Terraform
+
+terraform init
+
+# Next, create a plan file
+
+terraform plan -out tfplan.out
+
+# Review the plan file and apply once satisfied
+
+terraform apply "tfplan.out"
+```
 
 __Note: Functions not specified in `enabled_modules` will not be created and will be skipped.__
 
@@ -94,4 +110,4 @@ __Note: Functions not specified in `enabled_modules` will not be created and wil
 
 ## Limitation of Liability
 
-Please view the [License](LICENSE) for limitations of liability. 
+Please view the [License](LICENSE) for limitations of liability.

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -43,7 +43,7 @@
 #   }
 #   compute_default_sa = {
 #     lockdown_project = "test_project",
-#     name = "gcedefaultsa",
+#     name = "gcedefsa",
 #     log_sink_filter = "protoPayload.serviceName=\"compute.googleapis.com\" AND ((protoPayload.methodName=\"beta.compute.instances.insert\" AND protoPayload.request.serviceAccounts.email=~\"^\\d{1,18}-compute@developer.gserviceaccount.com$\") OR protoPayload.methodName=\"v1.compute.instances.start\") AND NOT protoPayload.authenticationInfo.principalEmail"
 #     function_perms = ["logging.logEntries.create", "pubsub.topics.publish", "compute.instances.get", "compute.instances.stop"],
 #   }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -44,7 +44,7 @@
 #   compute_default_sa = {
 #     lockdown_project = "test_project",
 #     name = "gcedefaultsa",
-#     log_sink_filter = "protoPayload.serviceName=\"compute.googleapis.com\" AND ((protoPayload.methodName=\"beta.compute.instances.insert\" AND protoPayload.request.serviceAccounts.email=~\"^\\d{1,12}-compute@developer.gserviceaccount.com$\") OR protoPayload.methodName=\"v1.compute.instances.start\") AND NOT protoPayload.authenticationInfo.principalEmail"
+#     log_sink_filter = "protoPayload.serviceName=\"compute.googleapis.com\" AND ((protoPayload.methodName=\"beta.compute.instances.insert\" AND protoPayload.request.serviceAccounts.email=~\"^\\d{1,18}-compute@developer.gserviceaccount.com$\") OR protoPayload.methodName=\"v1.compute.instances.start\") AND NOT protoPayload.authenticationInfo.principalEmail"
 #     function_perms = ["logging.logEntries.create", "pubsub.topics.publish", "compute.instances.get", "compute.instances.stop"],
 #   }
 #   legacy_gke_abac = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -124,7 +124,7 @@ resource "google_cloudfunctions_function" "cfn" {
   timeout               = 300
   entry_point           = "pubsub_trigger"
   service_account_email = google_service_account.cfn_sa.email
-  runtime               = "python37"
+  runtime               = "python38"
 
   event_trigger {
     event_type = "google.pubsub.topic.publish"


### PR DESCRIPTION
- Found a bug in our `compute_default_sa` `log_sink_filter` where we were only accounting for a project number to have 12 digits. During testing, mine had 13 so the Cloud Function was not invocating.

- Bumped python back to 3.8 and closes #36 Nothing changed on our end so GCP must have updated something. 

- Also updated the readme with more clear deployment instructions.

![bug_fix](https://user-images.githubusercontent.com/19151605/117024720-3f473500-acc8-11eb-8226-b919cbe6948c.gif)
